### PR TITLE
Comment out Tawk.to script in index.html to disable chat functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     <script type="module" src="/src/main.tsx"></script>
     
     <!--Start of Tawk.to Script-->
-    <script type="text/javascript">
+    <!-- <script type="text/javascript">
     var Tawk_API=Tawk_API||{}, Tawk_LoadStart=new Date();
     (function(){
     var s1=document.createElement("script"),s0=document.getElementsByTagName("script")[0];
@@ -56,7 +56,7 @@
     s1.setAttribute('crossorigin','*');
     s0.parentNode.insertBefore(s1,s0);
     })();
-    </script>
+    </script> -->
     <!--End of Tawk.to Script-->
   </body>
 </html>


### PR DESCRIPTION
This pull request makes a small change to the `index.html` file by commenting out the Tawk.to live chat script. This effectively disables the Tawk.to integration on the site while preserving the code for potential future use.